### PR TITLE
test: add vitest setup and data-service/api tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",
-		"prod": "next build && next start"
+		"prod": "next build && next start",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"dependencies": {
 		"@heroicons/react": "^2.1.5",

--- a/tests/api-cabins-route.test.js
+++ b/tests/api-cabins-route.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { getCabinMock, getBookedDatesMock } = vi.hoisted(() => ({
+  getCabinMock: vi.fn(),
+  getBookedDatesMock: vi.fn(),
+}));
+
+vi.mock("../app/_lib/data-service", () => ({
+  getCabin: getCabinMock,
+  getBookedDatesByCabinId: getBookedDatesMock,
+}));
+
+describe("GET /api/cabins/[cabinId]", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns cabin details and booked dates", async () => {
+    const date = new Date("2025-01-01T00:00:00.000Z");
+    getCabinMock.mockResolvedValue({ id: 1, name: "Test Cabin" });
+    getBookedDatesMock.mockResolvedValue([date]);
+
+    const { GET } = await import("../app/api/cabins/[cabinId]/route.js");
+    const response = await GET(new Request("http://localhost/api/cabins/1"), {
+      params: { cabinId: "1" },
+    });
+
+    const body = await response.json();
+
+    expect(getCabinMock).toHaveBeenCalledWith("1");
+    expect(getBookedDatesMock).toHaveBeenCalledWith("1");
+    expect(body).toEqual({
+      cabin: { id: 1, name: "Test Cabin" },
+      bookedDates: [date.toISOString()],
+    });
+  });
+
+  it("returns a fallback message when lookup fails", async () => {
+    getCabinMock.mockRejectedValue(new Error("boom"));
+    getBookedDatesMock.mockResolvedValue([]);
+
+    const { GET } = await import("../app/api/cabins/[cabinId]/route.js");
+    const response = await GET(new Request("http://localhost/api/cabins/1"), {
+      params: { cabinId: "1" },
+    });
+
+    const body = await response.json();
+
+    expect(body).toEqual({ message: "Cabin not found..." });
+  });
+});

--- a/tests/data-service.test.js
+++ b/tests/data-service.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { supabaseBrowserMock, supabaseServerMock, notFoundMock } = vi.hoisted(
+  () => ({
+    supabaseBrowserMock: { from: vi.fn() },
+    supabaseServerMock: { from: vi.fn() },
+    notFoundMock: vi.fn(() => {
+      throw new Error("NEXT_NOT_FOUND");
+    }),
+  })
+);
+
+vi.mock("../app/_lib/supabaseBrowser", () => ({
+  supabaseBrowser: supabaseBrowserMock,
+}));
+
+vi.mock("../app/_lib/supabaseServer", () => ({
+  supabaseServer: supabaseServerMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
+}));
+
+describe("data-service", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns cabins ordered by name", async () => {
+    const cabins = [{ id: 1, name: "A" }];
+    const order = vi.fn().mockResolvedValue({ data: cabins, error: null });
+    const select = vi.fn().mockReturnValue({ order });
+    supabaseBrowserMock.from.mockReturnValue({ select });
+
+    const { getCabins } = await import("../app/_lib/data-service");
+    const result = await getCabins();
+
+    expect(supabaseBrowserMock.from).toHaveBeenCalledWith("cabins");
+    expect(select).toHaveBeenCalledWith(
+      "id, name, maxCapacity, regularPrice, discount, image"
+    );
+    expect(order).toHaveBeenCalledWith("name");
+    expect(result).toEqual(cabins);
+  });
+
+  it("throws when cabins query fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const order = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: new Error("fail") });
+    const select = vi.fn().mockReturnValue({ order });
+    supabaseBrowserMock.from.mockReturnValue({ select });
+
+    const { getCabins } = await import("../app/_lib/data-service");
+
+    await expect(getCabins()).rejects.toThrow("Cabins could not be loaded");
+    consoleError.mockRestore();
+  });
+
+  it("calls notFound when a cabin lookup fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const single = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: new Error("fail") });
+    const eq = vi.fn().mockReturnValue({ single });
+    const select = vi.fn().mockReturnValue({ eq });
+    supabaseBrowserMock.from.mockReturnValue({ select });
+
+    const { getCabin } = await import("../app/_lib/data-service");
+
+    await expect(getCabin(42)).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFoundMock).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("returns booked dates for a cabin in UTC", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-10T12:00:00.000Z"));
+
+    const bookings = [
+      {
+        startDate: "2025-01-10T00:00:00.000Z",
+        endDate: "2025-01-12T00:00:00.000Z",
+      },
+    ];
+
+    const or = vi.fn().mockResolvedValue({ data: bookings, error: null });
+    const eq = vi.fn().mockReturnValue({ or });
+    const select = vi.fn().mockReturnValue({ eq });
+    supabaseBrowserMock.from.mockReturnValue({ select });
+
+    const { getBookedDatesByCabinId } = await import("../app/_lib/data-service");
+    const result = await getBookedDatesByCabinId(7);
+
+    expect(supabaseBrowserMock.from).toHaveBeenCalledWith("bookings");
+    expect(select).toHaveBeenCalledWith("*");
+    expect(eq).toHaveBeenCalledWith("cabinId", 7);
+    expect(or).toHaveBeenCalledWith(
+      "startDate.gte.2025-01-10T00:00:00.000Z,status.eq.checked-in"
+    );
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBeInstanceOf(Date);
+
+    vi.useRealTimers();
+  });
+
+  it("maps and filters countries from the API", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          name: { common: "Japan" },
+          flags: { svg: "jp.svg" },
+        },
+        {
+          name: { common: "" },
+          flags: { png: "empty.png" },
+        },
+      ],
+    });
+    globalThis.fetch = fetchMock;
+
+    const { getCountries } = await import("../app/_lib/data-service");
+    const countries = await getCountries();
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(countries).toEqual([{ name: "Japan", flag: "jp.svg" }]);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it("throws when the countries API request fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    globalThis.fetch = fetchMock;
+
+    const { getCountries } = await import("../app/_lib/data-service");
+
+    await expect(getCountries()).rejects.toThrow("Could not fetch countries");
+
+    globalThis.fetch = originalFetch;
+    consoleError.mockRestore();
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+const rootDir = fileURLToPath(new URL("./", import.meta.url));
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: ["./vitest.setup.js"],
+    clearMocks: true,
+    restoreMocks: true,
+    mockReset: true,
+  },
+  resolve: {
+    alias: {
+      "@": rootDir,
+    },
+  },
+});

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,1 @@
+process.env.TZ = "UTC";


### PR DESCRIPTION
Vitest 実行基盤を追加し、app/_lib/data-service と /api/cabins/[cabinId] のユニットテストを入れて、テスト計画の 9.2/9.3/9.4/9.7/9.8 を先行カバーしました。package.json にテスト用スクリプトを追加し、vitest.config.mjs/vitest.setup.js でエイリアスと UTC 固定の土台を整え、テストは data-service.test.js と api-cabins-route.test.js に集約しています。

Phase 1 Plan

変更方針: Vitest の最小構成を追加し、data-service と API ルートのユニットテストでエラー系/日付/外部 API 依存の観点を担保するため
追加/変更するファイル一覧: package.json, vitest.config.mjs, vitest.setup.js, data-service.test.js, api-cabins-route.test.js
実行するコマンド一覧: npm run test, git add package.json vitest.config.mjs vitest.setup.js tests, git commit -m "test: add vitest setup and data-service/api tests"
コミットメッセージ案: test: add vitest setup and data-service/api tests
Results

実行結果: npm run test 成功, git commit 成功
主要テストケース一覧（観点番号付き）: 9.2 キャビン一覧の並び順/取得失敗, 9.3 キャビン詳細の not-found 伝播, 9.4 予約済み日付の算出と UTC 固定, 9.7 国旗 API 成功/失敗時の挙動, 9.8 /api/cabins/[cabinId] の正常/異常応答
コミットハッシュ: 7025260
@coderabbitai review