### PR TITLE
fix: return 404 for cabin API errors

### DIFF
--- a/app/api/cabins/[cabinId]/route.js
+++ b/app/api/cabins/[cabinId]/route.js
@@ -10,7 +10,7 @@ export async function GET(request, { params }) {
 		]);
 		return Response.json({ cabin, bookedDates });
 	} catch {
-		return Response.json({ message: "Cabin not found..." });
+		return Response.json({ message: "Cabin not found..." }, { status: 404 });
 	}
 }
 

--- a/tests/api-cabins-route.test.js
+++ b/tests/api-cabins-route.test.js
@@ -46,6 +46,7 @@ describe("GET /api/cabins/[cabinId]", () => {
 
     const body = await response.json();
 
+    expect(response.status).toBe(404);
     expect(body).toEqual({ message: "Cabin not found..." });
   });
 });


### PR DESCRIPTION
Updated the cabin API error path to return a 404 and expanded the failing-case test to assert the status code, aligning the API behavior with the test plan’s error handling expectations. This change is localized to the API route and its unit test to ensure error responses are explicit and verified.

Phase Plan

変更方針: エラー時のHTTPステータスを明示し、9.8(APIルート)の品質基準に合わせるため
追加/変更するファイル一覧: route.js, api-cabins-route.test.js
実行するコマンド一覧: npm run test, api-cabins-route.test.js, git commit -m "fix: return 404 for cabin API errors"
コミットメッセージ案: fix: return 404 for cabin API errors
Results

実行結果: npm run test 成功, git commit 成功
主要テストケース一覧（観点番号付き）: 9.8 /api/cabins/[cabinId] エラー時に404を返す
コミットハッシュ: 54ff420
@coderabbitai review