### PR TITLE
Fix booking helpers and caching

### DIFF
--- a/app/_components/NavigationMenu.js
+++ b/app/_components/NavigationMenu.js
@@ -12,7 +12,11 @@ import { useState } from "react";
  * mobile panel on small screens. Displays an account link that shows the user's name and
  * avatar when `session.user.image` is present; otherwise shows a "Guest area" link.
  *
- * @param {{ user?: { name?: string, image?: string } }} session - Session object; when `user.image` is provided the component displays the user's avatar and name linking to `/account`.
+ * @param {object} props - Component props.
+ * @param {object} [props.session] - Session object; when `user.image` is provided the component displays the user's avatar and name linking to `/account`.
+ * @param {object} [props.session.user] - User object from the session.
+ * @param {string} [props.session.user.name] - User's display name.
+ * @param {string} [props.session.user.image] - User's avatar image URL.
  * @returns {JSX.Element} The navigation menu component.
  */
 function NavigationMenu({ session }) {

--- a/app/_lib/actions.js
+++ b/app/_lib/actions.js
@@ -12,6 +12,11 @@ import { getBookings } from "./data-service";
 import { normalizeNationalId } from "./guest";
 import { supabaseServer } from "./supabaseServer";
 
+function normalizeObservations(value) {
+  const observations = typeof value === "string" ? value : "";
+  return observations.slice(0, 1000);
+}
+
 /**
  * Update the authenticated guest's nationality, country flag, and national ID from submitted form data.
  *
@@ -90,13 +95,11 @@ export async function updateBooking(formData) {
     throw new Error("Number of guests exceeds cabin capacity");
   }
 
-  const observationsValue = formData.get("observations");
-  const observations =
-    typeof observationsValue === "string" ? observationsValue : "";
+  const observations = normalizeObservations(formData.get("observations"));
 
   const updateData = {
     numGuests,
-    observations: observations.slice(0, 1000),
+    observations,
   };
 
   const { error } = await supabaseServer
@@ -174,9 +177,7 @@ export async function createBooking(bookingData, formData) {
     cabin.regularPrice,
     cabin.discount
   );
-  const observationsValue = formData.get("observations");
-  const observations =
-    typeof observationsValue === "string" ? observationsValue : "";
+  const observations = normalizeObservations(formData.get("observations"));
 
   const newBooking = {
     startDate,
@@ -186,7 +187,7 @@ export async function createBooking(bookingData, formData) {
     cabinId,
     guestId,
     numGuests,
-    observations: observations.slice(0, 1000),
+    observations,
     extrasPrice: 0,
     totalPrice: cabinPrice,
     isPaid: false,

--- a/app/_lib/auth.js
+++ b/app/_lib/auth.js
@@ -17,8 +17,12 @@ async function getOrCreateGuestByEmail(email, name) {
     return await createGuest({ email, fullName: name ?? null });
   } catch (error) {
     if (error?.code === "23505") {
-      const createdByAnotherRequest = await getGuest(email);
-      if (createdByAnotherRequest) return createdByAnotherRequest;
+      try {
+        const createdByAnotherRequest = await getGuest(email);
+        if (createdByAnotherRequest) return createdByAnotherRequest;
+      } catch (retryError) {
+        throw retryError;
+      }
     }
     throw error;
   }


### PR DESCRIPTION
Committed the pending changes and aligned caching so unit tests pass in the Vitest environment.

NavigationMenu.js JSDoc now reflects the actual props.session.user shape.
actions.js extracted normalizeObservations and reused it in update/create flows.
auth.js rethrow the retry error when getGuest fails after a unique-constraint hit.
data-service.js switched to React cache with a safe fallback for test runtime, keeping revalidation on fetch.
Commit: d61428c

Tests:

npm run test:unit
@coderabbitai review