### PR TITLE
chore: unify env variables and pin Node.js version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.19.6, 22.x]
     env:
       # Skip Playwright browser download for non-E2E jobs
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 20.19.6
           cache: npm
       - name: Install dependencies
         run: npm ci

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,12 +20,13 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     env: {
       NEXT_PUBLIC_SUPABASE_URL: "http://localhost:54321",
-      NEXT_PUBLIC_SUPABASE_KEY: "test-anon-key",
+      NEXT_PUBLIC_SUPABASE_KEY: "test",
       SUPABASE_URL: "http://localhost:54321",
-      SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
-      AUTH_GOOGLE_ID: "test-google-id",
-      AUTH_GOOGLE_SECRET: "test-google-secret",
-      AUTH_SECRET: "test-auth-secret",
+      SUPABASE_SERVICE_ROLE_KEY: "test",
+      AUTH_GOOGLE_ID: "test",
+      AUTH_GOOGLE_SECRET: "test",
+      NEXTAUTH_URL: "http://localhost:3000",
+      NEXTAUTH_SECRET: "test-secret",
     },
   },
   projects: [


### PR DESCRIPTION
- Align playwright.config.ts env variables with CI workflow:
  - Use consistent test values across both configurations
  - Add NEXTAUTH_URL and NEXTAUTH_SECRET (was AUTH_SECRET)
- Pin Node.js to 20.19.6 in CI (lint-and-test matrix and e2e job) to ensure security patches are applied consistently with .nvmrc

🤖 Generated with [Claude Code](https://claude.com/claude-code)