### PR TITLE
fix: preserve date selection on booking error

### DIFF
--- a/app/_components/ReservationForm.jsx
+++ b/app/_components/ReservationForm.jsx
@@ -63,8 +63,13 @@ function ReservationForm({ cabin, user }) {
 
 				<form
 				action={async (formData) => {
-					await createBookingWithData(formData);
-					resetRange();
+					try {
+						await createBookingWithData(formData);
+						resetRange();
+					} catch (error) {
+						// エラー時は日付選択を保持（Server Actionはエラーを再スローするのでUIに伝播）
+						throw error;
+					}
 				}}
 				className="flex flex-1 flex-col gap-5 bg-primary-900 px-4 py-6 text-sm sm:gap-6 sm:px-8 sm:py-8 sm:text-base md:gap-7 md:px-10 md:py-10"
 			>


### PR DESCRIPTION
Wrap createBookingWithData in try-catch to ensure resetRange() only runs on success. On error, the date selection is preserved and the error is re-thrown to propagate to the UI error boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)