### PR TITLE
docs: update progress and specs for TypeScript Phase 2-4 completion

### DIFF
--- a/app/_components/TextExpander.tsx
+++ b/app/_components/TextExpander.tsx
@@ -15,7 +15,7 @@ interface TextExpanderProps {
 function TextExpander({ children }: TextExpanderProps) {
 	const [isExpanded, setIsExpanded] = useState(false);
 	const words = children.trim().split(/\s+/);
-	const isLongText = words.length > 40 && children.trim().length > 0;
+	const isLongText = words.length > 40;
 	const displayText =
 		isExpanded || !isLongText ? children : words.slice(0, 40).join(" ") + "...";
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -5,6 +5,18 @@ Status: 未確認 / 確認中 / 完了 / 差し戻し
 
 | Status | Commit | Date | Summary | Notes |
 | --- | --- | --- | --- | --- |
+| 完了 | 988f063 | 2025-12-31 | fix: address CodeRabbit review feedback (round 5) | Counter動的aria-label、TextExpander改善 |
+| 完了 | 38b8896 | 2025-12-31 | fix: address additional CodeRabbit review feedback | アクセシビリティ・UX改善 |
+| 完了 | fb75e3e | 2025-12-31 | fix: address CodeRabbit review feedback for Phase 4 TypeScript migration | Phase 4レビュー対応 |
+| 完了 | e84fe72 | 2025-12-31 | 📝 Add docstrings to `macbook-dev` | JSDoc追加 |
+| 完了 | 4b5005b | 2025-12-31 | refactor: migrate React components and pages to TypeScript (Phase 4) | **TypeScript Phase 4 完了** |
+| 完了 | a29d97b | 2025-12-31 | refactor: address code review feedback for Phase 3 migration | Phase 3レビュー対応 |
+| 完了 | f86a596 | 2025-12-31 | refactor: migrate API routes and middleware to TypeScript (Phase 3) | **TypeScript Phase 3 完了** |
+| 完了 | f520c8e | 2025-12-31 | fix: preserve date selection on booking error | 予約エラー時の日付保持 |
+| 完了 | b281c68 | 2025-12-31 | refactor: address code review feedback for Phase 2 migration | Phase 2レビュー対応 |
+| 完了 | 4e351fc | 2025-12-31 | refactor: migrate app/_lib to TypeScript (Phase 2) | **TypeScript Phase 2 完了** |
+| 完了 | 372d287 | 2025-12-31 | docs: record TypeScript Phase 1 performance baselines | パフォーマンスベースライン記録 |
+| 完了 | b518d3c | 2025-12-31 | docs: address review feedback on specs and migration plan | 仕様書・計画レビュー対応 |
 | 完了 | ffe6cea | 2025-12-30 | docs: add MockLinkProps interface and version constraint rationale | TypeScript Phase 1 最終レビュー対応 |
 | 完了 | 93a624d | 2025-12-30 | refactor: address additional code review feedback | TypeScript Phase 1 追加レビュー対応 |
 | 完了 | 3f95872 | 2025-12-30 | docs: address review feedback on TypeScript migration plan | マイグレーション計画レビュー対応 |
@@ -42,6 +54,70 @@ Status: 未確認 / 確認中 / 完了 / 差し戻し
 ## 作業ログ（統合）
 
 このセクションに `docs/README_20251018.md` と `docs/2025-10-13-postgres-maintenance.md` の内容を統合して管理する。
+
+### 2025-12-31 変更内容まとめ（詳細）
+
+#### 概要
+
+- **TypeScript Phase 2〜4 完了**
+- CodeRabbitレビュー対応（5ラウンド）
+- アクセシビリティ・UX改善
+
+#### TypeScript Phase 2: データ/認証レイヤー移行（完了）
+
+- 対象ファイル:
+  - `app/_lib/errors.js` → `.ts`
+  - `app/_lib/guest.js` → `.ts`
+  - `app/_lib/supabaseServer.js` → `.ts`
+  - `app/_lib/supabaseBrowser.js` → `.ts`
+  - `app/_lib/booking.js` → `.ts`
+  - `app/_lib/data-service.js` → `.ts`
+  - `app/_lib/auth.js` → `.ts`
+  - `app/_lib/actions.js` → `.ts`
+- 変更内容:
+  - `BookingError`クラスと`mapSupabaseError`関数の型定義
+  - `DateRange`、`BookingValidationInput`インターフェース追加
+  - `BookingWithCabin`、`BookingListItem`、`NewGuestInput`インターフェース追加
+  - NextAuth設定とコールバックの型定義（`NextAuthOptions`）
+  - Server Actionsの`FormData`ハンドリング型定義
+- 効果:
+  - データレイヤーの完全な型安全性
+  - 全77ユニットテスト + 22コンポーネントテスト通過
+
+#### TypeScript Phase 3: API ルート & Middleware 移行（完了）
+
+- 対象ファイル:
+  - `middleware.js` → `middleware.ts`
+  - `app/api/auth/[...nextauth]/route.js` → `.ts`
+  - `app/api/cabins/[cabinId]/route.js` → `.ts`
+  - `app/api/health/route.js` → `.ts`
+- 変更内容:
+  - `withAuth`設定に`NextAuthMiddlewareOptions`型を適用
+  - APIレスポンスに`NextResponse<T>`型を適用
+- 効果:
+  - ミドルウェアとAPIルートの型安全性確保
+
+#### TypeScript Phase 4: コンポーネント & ページ移行（完了）
+
+- 対象ファイル:
+  - コンポーネント: 27ファイル（`.jsx` → `.tsx`）
+  - ページ/レイアウト: 18ファイル（`.jsx` → `.tsx`）
+- 変更内容:
+  - 全コンポーネントにPropsインターフェース定義
+  - `params`と`searchParams`の型定義
+  - `generateMetadata`と`generateStaticParams`の型定義
+  - JSDocコメント追加
+- 効果:
+  - UIレイヤーの完全な型安全性
+  - 開発時の補完とエラー検出が向上
+
+#### CodeRabbitレビュー対応
+
+- 5ラウンドにわたるレビュー対応
+- 主な改善:
+  - アクセシビリティ: `aria-label`、`aria-expanded`、`role`属性追加
+  - UX: 動的ラベル、レスポンシブ対応、エラーハンドリング
+  - コード品質: 空白文字処理改善、JSDoc更新、冗長チェック削除
 
 ### 2025-12-30 変更内容まとめ（詳細）
 

--- a/specs/index.md
+++ b/specs/index.md
@@ -19,7 +19,7 @@
 |----|------|--------|------|
 | 001 | [sample-feature](001-sample-feature/) | サンプル | テンプレートの使用例 |
 | 002 | [booking-concurrency-control](002-booking-concurrency-control/) | DB制約実装完了 | 予約の同時実行対策（重複予約防止） |
-| 003 | [typescript-migration](../typescript-migration-plan.md) | **Phase 1完了** | JSからTSへの段階的移行 |
+| 003 | [typescript-migration](../typescript-migration-plan.md) | **Phase 4完了** | JSからTSへの段階的移行 |
 
 ## 詳細
 
@@ -53,12 +53,12 @@
 - **目的**: JavaScript から TypeScript への段階的移行（挙動を変えない）
 - **ファイル**: [typescript-migration-plan.md](../typescript-migration-plan.md)
   - ※ 詳細な計画（700行以上）のため、専用ファイルで管理
-- **現在のステータス**: **Phase 1 完了**（基盤構築）
+- **現在のステータス**: **Phase 4 完了**（コンポーネント & ページ移行）
 - **Phase 概要**:
   - Phase 1: 基盤構築（tsconfig.json、型定義ファイル）✅ 完了
-  - Phase 2: データ/認証レイヤー移行（`app/_lib/*.js` → `.ts`）
-  - Phase 3: API ルート & Middleware 移行
-  - Phase 4: コンポーネント & ページ移行（`.jsx` → `.tsx`）
+  - Phase 2: データ/認証レイヤー移行（`app/_lib/*.js` → `.ts`）✅ 完了
+  - Phase 3: API ルート & Middleware 移行 ✅ 完了
+  - Phase 4: コンポーネント & ページ移行（`.jsx` → `.tsx`）✅ 完了
   - Phase 5: Strict モード解決 & 最終化
   - Phase 6: テストファイル移行
 - **成果物**:

--- a/typescript-migration-plan.md
+++ b/typescript-migration-plan.md
@@ -223,43 +223,43 @@ npm install -D typescript@~5.7.2 @types/node@^20.0.0 @types/react@^18.0.0 @types
    - Added `CreateBookingData` interface
    - All 77 unit tests + 22 component tests passing
 
-### Phase 3: API Routes & Middleware
+### Phase 3: API Routes & Middleware ✅ (Completed: 2025-12-31)
 
-- [ ] `middleware.js` → `middleware.ts`
-  - Type withAuth config
-- [ ] `app/api/auth/[...nextauth]/route.js` → `.ts`
+- [x] `middleware.js` → `middleware.ts`
+  - Type withAuth config with `NextAuthMiddlewareOptions`
+- [x] `app/api/auth/[...nextauth]/route.js` → `.ts`
   - Type route handlers
-- [ ] `app/api/cabins/[cabinId]/route.js` → `.ts`
-  - Type params and response
-- [ ] `app/api/health/route.js` → `.ts`
-  - Type response
+- [x] `app/api/cabins/[cabinId]/route.js` → `.ts`
+  - Type params and response with `NextResponse<Cabin>`
+- [x] `app/api/health/route.js` → `.ts`
+  - Type response with `NextResponse<{ status: string }>`
 
-### Phase 4: Components & Pages (.jsx → .tsx)
+### Phase 4: Components & Pages (.jsx → .tsx) ✅ (Completed: 2025-12-31)
 
-#### Components (27 files)
+#### Components (27 files) ✅
 
-- [ ] Context: `ReservationContext.jsx` → `.tsx`
+- [x] Context: `ReservationContext.jsx` → `.tsx`
   - Define context type with DateRange
-- [ ] Forms: `UpdateProfileForm.jsx`, `ReservationForm.jsx` → `.tsx`
+- [x] Forms: `UpdateProfileForm.jsx`, `ReservationForm.jsx` → `.tsx`
   - Type form props and Server Action bindings
-- [ ] Cards: `CabinCard.jsx`, `ReservationCard.jsx` → `.tsx`
-- [ ] Lists: `CabinList.jsx`, `ReservationList.jsx` → `.tsx`
-- [ ] Navigation: `Navigation.jsx`, `NavigationMenu.jsx`, `SideNavigation.jsx` → `.tsx`
-- [ ] Auth: `SignInButton.jsx`, `SignOutButton.jsx` → `.tsx`
-- [ ] UI: `Spinner.jsx`, `SpinnerMini.jsx`, `SubmitButton.jsx`, etc. → `.tsx`
-- [ ] Other: `Cabin.jsx`, `DateSelector.jsx`, `Filter.jsx`, `Header.jsx`, `Logo.jsx`, etc. → `.tsx`
+- [x] Cards: `CabinCard.jsx`, `ReservationCard.jsx` → `.tsx`
+- [x] Lists: `CabinList.jsx`, `ReservationList.jsx` → `.tsx`
+- [x] Navigation: `Navigation.jsx`, `NavigationMenu.jsx`, `SideNavigation.jsx` → `.tsx`
+- [x] Auth: `SignInButton.jsx`, `SignOutButton.jsx` → `.tsx`
+- [x] UI: `Spinner.jsx`, `SpinnerMini.jsx`, `SubmitButton.jsx`, etc. → `.tsx`
+- [x] Other: `Cabin.jsx`, `DateSelector.jsx`, `Filter.jsx`, `Header.jsx`, `Logo.jsx`, etc. → `.tsx`
 
-#### Pages & Layouts (18 files)
+#### Pages & Layouts (18 files) ✅
 
-- [ ] Root: `app/page.jsx`, `app/layout.jsx`, `app/error.jsx`, `app/not-found.jsx`, `app/loading.jsx` → `.tsx`
-- [ ] About: `app/about/page.jsx` → `.tsx`
-- [ ] Login: `app/login/page.jsx` → `.tsx`
-- [ ] Cabins: `app/cabins/page.jsx`, `app/cabins/[cabinId]/page.jsx`, etc. → `.tsx`
+- [x] Root: `app/page.jsx`, `app/layout.jsx`, `app/error.jsx`, `app/not-found.jsx`, `app/loading.jsx` → `.tsx`
+- [x] About: `app/about/page.jsx` → `.tsx`
+- [x] Login: `app/login/page.jsx` → `.tsx`
+- [x] Cabins: `app/cabins/page.jsx`, `app/cabins/[cabinId]/page.jsx`, etc. → `.tsx`
   - Type `params` and `searchParams`
   - Type `generateMetadata` and `generateStaticParams`
-- [ ] Account: `app/account/page.jsx`, `app/account/layout.jsx`, etc. → `.tsx`
-- [ ] Reservations: `app/account/reservations/page.jsx`, `app/account/reservations/edit/[bookingId]/page.jsx` → `.tsx`
-- [ ] Profile: `app/account/profile/page.jsx` → `.tsx`
+- [x] Account: `app/account/page.jsx`, `app/account/layout.jsx`, etc. → `.tsx`
+- [x] Reservations: `app/account/reservations/page.jsx`, `app/account/reservations/edit/[bookingId]/page.jsx` → `.tsx`
+- [x] Profile: `app/account/profile/page.jsx` → `.tsx`
 
 ### Phase 5: Strict Mode Resolution & Finalization
 


### PR DESCRIPTION
Progress updates:
- specs/index.md: Update TypeScript migration status to Phase 4 complete
- typescript-migration-plan.md: Mark Phase 3 and Phase 4 as completed
- docs/progress.md: Add 12 new commits and 2025-12-31 work log

Code fix:
- TextExpander.tsx: Remove redundant children.trim().length check

🤖 Generated with [Claude Code](https://claude.com/claude-code)