### PR TITLE
feat: implement idempotency key for booking duplicate prevention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,12 @@ next-env.d.ts
 .env
 .vscode
 config.toml
-supabase
+
+# Supabase CLI generated files (but keep migrations)
+supabase/.branches/
+supabase/.temp/
+.supabase/
+!supabase/migrations/
 
 # Kilo Code / Spec Kit cache
 .kilocode/.cache/

--- a/app/_components/ReservationForm.tsx
+++ b/app/_components/ReservationForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { calculateNumNights } from "@/app/_lib/booking";
 import { useReservation } from "./ReservationContext";
 import { createBooking, type CreateBookingData } from "../_lib/actions";
@@ -40,11 +41,20 @@ function ReservationForm({ cabin, user }: ReservationFormProps) {
 	const numNights =
 		startDate && endDate ? calculateNumNights(startDate, endDate) : 0;
 
+	// Generate a unique client request ID for idempotency
+	// This ID stays the same for a given date range + cabin combination
+	// and regenerates when the user changes dates
+	const clientRequestId = useMemo(() => {
+		if (!startDate || !endDate) return undefined;
+		return crypto.randomUUID();
+	}, [startDate?.getTime(), endDate?.getTime(), id]);
+
 	const bookingData: CreateBookingData = {
 		startDate: startDate ?? null,
 		endDate: endDate ?? null,
 		numNights,
 		cabinId: id,
+		clientRequestId,
 	};
 
 	const createBookingWithData = createBooking.bind(null, bookingData);

--- a/app/_lib/actions.ts
+++ b/app/_lib/actions.ts
@@ -26,6 +26,8 @@ export interface CreateBookingData {
   endDate: string | Date | null;
   numNights: number;
   cabinId: string | number;
+  /** Client-generated UUID for idempotency (prevents duplicate submissions) */
+  clientRequestId?: string;
 }
 
 /**
@@ -205,6 +207,9 @@ export async function createBooking(
     isPaid: false,
     hasBreakfast: false,
     status: "unconfirmed" as const,
+    ...(bookingData.clientRequestId && {
+      clientRequestId: bookingData.clientRequestId,
+    }),
   };
 
   const { error } = await supabaseServer.from("bookings").insert([newBooking]);

--- a/specs/002-booking-concurrency-control/tasks.md
+++ b/specs/002-booking-concurrency-control/tasks.md
@@ -9,7 +9,7 @@
 - [x] migration 適用（Supabase SQL Editorで実行）（2025-12-25完了）
 - [x] トリガー例外の SQLSTATE を決定（P0001 + メッセージ）（保留: トリガーなしで運用）
 - [x] `createBooking` のエラーコード変換（23P01/23514/23505/P0001）（2025-12-28完了）
-- [ ] idempotency key の導入可否を決定（将来検討）
+- [x] idempotency key の導入可否を決定（2026-01-01完了: 導入決定、実装完了）
 - [x] ローカル環境で並列予約テストを実施（2026-01-01完了: Docker Postgres 17）
 - [x] パフォーマンス影響の計測（2026-01-01完了: Docker Postgres 17でベンチマーク実施）
 - [x] 監視・ログの文言を定義（PII なし）（2025-12-28完了: errors.jsで実装）
@@ -37,9 +37,13 @@
 - [x] `startDate >= endDate` で拒否される（2026-01-01検証: 23514エラー）
 - [x] `numGuests = 0` で拒否される（2026-01-01検証: 23514エラー）
 
+### idempotency key（実装済み）
+- [x] clientRequestId カラム追加（2026-01-01: migration作成）
+- [x] クライアント側でUUID生成（2026-01-01: ReservationForm.tsx）
+- [ ] idempotency key の重複で 409（migration適用後に検証予定）
+
 ### 未実装（将来対応）
 - [ ] `numGuests > maxCapacity` で拒否される（トリガー未実装のため未検証）
-- [ ] idempotency key の重複で 409（未実装のため未検証）
 - [ ] CAPACITY_EXCEEDED の P0001 が 400 に変換される（トリガー未実装のため未検証）
 
 ### ローカル並列予約テスト結果（2026-01-01）

--- a/supabase/migrations/20260101_add_idempotency_key.sql
+++ b/supabase/migrations/20260101_add_idempotency_key.sql
@@ -1,0 +1,16 @@
+-- Migration: Add idempotency key for duplicate request prevention
+-- Date: 2026-01-01
+-- Description: Adds clientRequestId column to bookings table with unique constraint
+
+-- Add nullable UUID column for idempotency key
+ALTER TABLE bookings
+ADD COLUMN "clientRequestId" uuid;
+
+-- Create partial unique index (only for non-null values)
+-- This allows existing records without clientRequestId while preventing duplicates
+CREATE UNIQUE INDEX bookings_client_request_id_unique
+ON bookings ("clientRequestId")
+WHERE "clientRequestId" IS NOT NULL;
+
+-- Add comment for documentation
+COMMENT ON COLUMN bookings."clientRequestId" IS 'Client-generated UUID for idempotency. Prevents duplicate bookings from double-clicks or network retries.';


### PR DESCRIPTION
Phase 1 - Idempotency Key Implementation:
- Add clientRequestId column migration for bookings table
- Generate client-side UUID using crypto.randomUUID() in ReservationForm
- Pass clientRequestId through CreateBookingData to server action
- Update .gitignore to track supabase/migrations while ignoring CLI files

The clientRequestId regenerates when date selection changes, ensuring the same booking attempt uses the same key for retry protection.

Migration note: Apply 20260101_add_idempotency_key.sql to production after deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)