### PR TITLE
fix: handle empty string in HASH_SALT fallback logic

### DIFF
--- a/app/_lib/logger.ts
+++ b/app/_lib/logger.ts
@@ -24,7 +24,7 @@ function getEffectiveSalt(): string {
     }
   }
 
-  validatedSalt = salt ?? "default-salt-for-development-only";
+  validatedSalt = salt || "default-salt-for-development-only";
   return validatedSalt;
 }
 


### PR DESCRIPTION
- Use || instead of ?? to catch empty strings in development fallback
- Update progress.md with 2026-01-02 code review responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)