### PR TITLE
feat(db): add capacity check trigger for bookings

### DIFF
--- a/specs/002-booking-concurrency-control/spec.md
+++ b/specs/002-booking-concurrency-control/spec.md
@@ -308,13 +308,13 @@ where id in (select id from conflicts);
 | `startDate`/`endDate` の型 | `timestamp without time zone` → `tsrange` を使用 |
 | 予約更新で日付変更を許可するか | 現時点では許可（制約により重複は自動防止）|
 
-## 実装状況（2025-12-25）
+## 実装状況（2026-01-03更新）
 
 - [x] 重複データのクリーンアップ完了（id: 89, 124, 126 を削除）
 - [x] `btree_gist` 拡張有効化
 - [x] `bookings_no_overlap` 排他制約追加（`WHERE (status <> 'canceled')` 付き）
 - [x] `bookings_date_order` チェック制約追加
 - [x] `bookings_num_guests` チェック制約追加
-- [ ] キャパシティチェックトリガー（将来対応）
-- [ ] idempotency key（将来対応）
-- [ ] SQLSTATE→HTTP マッピング（Phase 2.1 で対応予定）
+- [x] キャパシティチェックトリガー（2026-01-03完了: `check_booking_capacity()` 関数 + トリガー）
+- [x] idempotency key（2026-01-01完了: `clientRequestId` カラム + unique index）
+- [x] SQLSTATE→HTTP マッピング（2025-12-28完了: `errors.ts` で実装）

--- a/specs/002-booking-concurrency-control/tasks.md
+++ b/specs/002-booking-concurrency-control/tasks.md
@@ -46,9 +46,13 @@
 **注**: マイグレーション `20260101_add_idempotency_key.sql` は各環境で適用が必要。
 適用後、同一 `clientRequestId` での二重送信は 23505 (unique violation) → 409 Conflict で拒否される。
 
-### 未実装（将来対応）
-- [ ] `numGuests > maxCapacity` で拒否される（トリガー未実装のため未検証）
-- [ ] CAPACITY_EXCEEDED の P0001 が 400 に変換される（トリガー未実装のため未検証）
+### キャパシティチェックトリガー（2026-01-03実装）
+- [x] `numGuests > maxCapacity` で拒否される（トリガー実装: P0001 CAPACITY_EXCEEDED）
+- [x] CAPACITY_EXCEEDED の P0001 が 400 に変換される（errors.ts で実装済み）
+- [x] CABIN_NOT_FOUND の P0001 が 404 に変換される（errors.ts で実装済み）
+
+**マイグレーションファイル**: `supabase/migrations/20260103_add_capacity_check_trigger.sql`
+**ロールバック**: `supabase/migrations/20260103_add_capacity_check_trigger_rollback.sql`
 
 ### ローカル並列予約テスト結果（2026-01-01）
 

--- a/supabase/migrations/20260103_add_capacity_check_trigger.sql
+++ b/supabase/migrations/20260103_add_capacity_check_trigger.sql
@@ -1,0 +1,48 @@
+-- Migration: Add capacity check trigger for bookings
+-- Date: 2026-01-03
+-- Description: Ensures numGuests does not exceed cabin's maxCapacity
+--
+-- Related: specs/002-booking-concurrency-control/spec.md
+-- Error codes:
+--   - P0001 with message 'CAPACITY_EXCEEDED': numGuests > maxCapacity
+--   - P0001 with message 'CABIN_NOT_FOUND': cabinId does not exist in cabins table
+
+-- Create the trigger function
+CREATE OR REPLACE FUNCTION check_booking_capacity()
+RETURNS trigger AS $$
+DECLARE
+  max_cap int;
+BEGIN
+  -- Get maxCapacity from cabins table
+  SELECT "maxCapacity" INTO max_cap
+  FROM cabins
+  WHERE id = NEW."cabinId";
+
+  -- Check if cabin exists
+  IF max_cap IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = 'P0001',
+      MESSAGE = 'CABIN_NOT_FOUND';
+  END IF;
+
+  -- Check if numGuests exceeds capacity
+  IF NEW."numGuests" > max_cap THEN
+    RAISE EXCEPTION USING
+      ERRCODE = 'P0001',
+      MESSAGE = 'CAPACITY_EXCEEDED';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the trigger (drop if exists for idempotency)
+DROP TRIGGER IF EXISTS bookings_capacity_check ON bookings;
+
+CREATE TRIGGER bookings_capacity_check
+  BEFORE INSERT OR UPDATE ON bookings
+  FOR EACH ROW
+  EXECUTE FUNCTION check_booking_capacity();
+
+-- Verification query (run after migration to confirm trigger exists)
+-- SELECT tgname, tgtype FROM pg_trigger WHERE tgrelid = 'bookings'::regclass;

--- a/supabase/migrations/20260103_add_capacity_check_trigger_rollback.sql
+++ b/supabase/migrations/20260103_add_capacity_check_trigger_rollback.sql
@@ -1,0 +1,12 @@
+-- Rollback: Remove capacity check trigger
+-- Date: 2026-01-03
+-- Use this script to rollback the capacity check trigger if needed
+
+-- Drop the trigger
+DROP TRIGGER IF EXISTS bookings_capacity_check ON bookings;
+
+-- Drop the function
+DROP FUNCTION IF EXISTS check_booking_capacity();
+
+-- Verification query (run after rollback to confirm removal)
+-- SELECT tgname FROM pg_trigger WHERE tgrelid = 'bookings'::regclass;


### PR DESCRIPTION
Implement PostgreSQL trigger to validate numGuests against cabin maxCapacity:
- CAPACITY_EXCEEDED (P0001 → 400) when numGuests > maxCapacity
- CABIN_NOT_FOUND (P0001 → 404) when cabinId doesn't exist

Migration and rollback scripts included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)